### PR TITLE
Warn of undefined method errors when loading configuration files for Rails

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -81,7 +81,9 @@ class Configurable
           pathname = Rails.root.join 'config', 'app'
           require_dependency pathname.to_s
           require_dependency pathname.join(Rails.env).to_s
-        rescue LoadError, NoMethodError
+        rescue NoMethodError => e
+          Rails.logger.warn e
+        rescue LoadError
         end
       end
 


### PR DESCRIPTION
Confusing situations can arise when configuration files are loaded and a no method error occurs. This can cause part or all of a configuration file not to load, silently.
