### PR TITLE
RSpec 4 compatibility: override #respond_to? method

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -42,8 +42,8 @@ class Configurable
       @logger ||= Logger.new STDERR
     end
 
-    def respond_to?(method_sym, include_private = false)
-      config.respond_to?(method_sym) || super
+    def respond_to_missing?(method_sym, include_private = false)
+      config.respond_to?(method_sym.to_s.gsub(/\?$/, ''), include_private) || super
     end
 
     private

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -3,11 +3,19 @@ require 'app'
 require 'stringio'
 
 class App < Configurable
-  config.logger = Logger.new StringIO.new
+  config.logger   = Logger.new StringIO.new
 
-  config.tubular = "way cool"
-  config.awesome = nil
-  config.mondo = lambda { |a, b| return a, b }
+  config.tubular  = "way cool"
+  config.awesome  = nil
+  config.mondo    = lambda { |a, b| return a, b }
+
+  config.can_do   = false
+  def self.can_do?
+    true
+  end
+
+  def self.destroy_something!
+  end
 end
 
 class AppTest < ActiveSupport::TestCase
@@ -18,10 +26,26 @@ class AppTest < ActiveSupport::TestCase
   end
 
   test 'should have new methods' do
+    assert_equal true, App.respond_to?(:can_do?)
+    assert_nothing_raised { App.method(:can_do?) }
+    assert_equal true, App.can_do?
+    assert_equal false, App.can_do
+
+    assert_equal true, App.respond_to?(:destroy_something!)
+    assert_nothing_raised { App.method(:destroy_something!) }
+
+
     assert_equal true, App.respond_to?(:tubular)
+    assert_equal true, App.respond_to?(:tubular?)
+    assert_nothing_raised { App.method(:tubular) }
+
     assert_equal true, App.respond_to?(:awesome)
-    assert_equal true, App.respond_to?(:mondo)
+    assert_equal true, App.respond_to?(:awesome?)
+    assert_nothing_raised { App.method(:awesome) }
+
     assert_equal false, App.respond_to?(:tubular111)
+    assert_equal false, App.respond_to?(:tubular111?)
+    assert_raise(NameError) { App.method(:tubular111) }
   end
 
   test "should return booleans" do


### PR DESCRIPTION
According to:

```
  config.mock_with :rspec do |mocks|
    # Prevents you from mocking or stubbing a method that does not exist on
    # a real object. This is generally recommended, and will default to
    # `true` in RSpec 4.
    mocks.verify_partial_doubles = true
  end
```

and [rspec-mocks](https://github.com/rspec/rspec-mocks/blob/a32ecea6d20931c141a0e39c5f52d09633f8d892/lib/rspec/mocks/method_reference.rb#L83-L95)
